### PR TITLE
2352: Introduce end dates/time on events

### DIFF
--- a/src/components/EventSummary/EventSummary.scss
+++ b/src/components/EventSummary/EventSummary.scss
@@ -55,7 +55,7 @@
 }
 
 .event-summary-card__h4 {
-  font-size: pxtorem(20px);
+  font-size: pxtorem(18px);
   margin-bottom: pxtorem(16px);
 }
 

--- a/src/components/EventSummary/EventSummary.tsx
+++ b/src/components/EventSummary/EventSummary.tsx
@@ -22,7 +22,10 @@ const EventSummary: React.FunctionComponent<IProps> = ({ event, history }) => {
     return null;
   }
 
-  const { id, title, is_free, is_virtual, start_date, start_time, organisation_id, intro } = event;
+  const { id, title, is_free, is_virtual, start_date, start_time, end_date, end_time, organisation_id, intro } = event;
+
+  const eventStartDateFormatted = start_date ?  moment(start_date).format('ddd Do MMMM') : null
+  const eventEndDateFormatted = end_date ? moment(end_date).format('ddd Do MMMM') : null
 
   return (
     <div key={id} className="event-summary-card" onClick={() => history.push(`/events/${id}`)}>
@@ -38,7 +41,8 @@ const EventSummary: React.FunctionComponent<IProps> = ({ event, history }) => {
             </div>
           </div>
           <h4 className="event-summary-card__h4">
-            {moment(start_date).format('dddd MMMM Do')} - {formatTimeFromString(start_time)}
+            {`${eventStartDateFormatted} ${formatTimeFromString(start_time)}`}{' '}
+            { moment(start_date).isSame(end_date) ? `- ${end_time && formatTimeFromString(end_time)} ` : eventEndDateFormatted ? `- ${ eventEndDateFormatted} ${end_time && formatTimeFromString(end_time)}  ` : null }
           </h4>
         </div>
         <div className="search-result-card__logo">

--- a/src/views/EventDetail/EventDetail.tsx
+++ b/src/views/EventDetail/EventDetail.tsx
@@ -62,6 +62,8 @@ const EventDetail: React.FC<IProps> = ({ eventStore, match }) => {
   const getOrganisationUrl = event.organiser_url || (organisation && organisation.url);
   const getOrganisationPhone = event.organiser_phone || (organisation && organisation.phone);
   const getOrganisationEmail = event.organiser_email || (organisation && organisation.email);
+  const eventStartDateFormatted = event.start_date ?  moment(event.start_date).format('dddd Do MMMM') : null
+  const eventEndDateFormatted = event.end_date ? moment(event.end_date).format('dddd Do MMMM') : null
 
   return (
     <section className="event__detail">
@@ -143,8 +145,9 @@ const EventDetail: React.FC<IProps> = ({ eventStore, match }) => {
             <div className="panel-box__white--large margin-bottom">
               <div className="event-summary-card__pills flex--justify-space">
                 <h3 className="h3 event-summary-card__tag event-summary-card__tag--date-time">
-                  {moment(event.start_date).format('dddd MMMM Do')} -{' '}
-                  {formatTimeFromString(event.start_time)}
+                  { /* If start date and end date same, show just end time (not end date) */ }
+                  {`${eventStartDateFormatted} ${formatTimeFromString(event.start_time)}`}{' '}
+                  { moment(event.start_date).isSame(event.end_date) ? `- ${event.end_time && formatTimeFromString(event.end_time)} ` : eventEndDateFormatted ? `- ${ eventEndDateFormatted} ${event.end_time && formatTimeFromString(event.end_time)}  ` : null }
                 </h3>
                 <div className="flex--align--start">
                   <div className="event-summary-card__tag event-summary-card__tag--cost">

--- a/src/views/Service/timeFormatting.ts
+++ b/src/views/Service/timeFormatting.ts
@@ -81,7 +81,7 @@ export const formatHolidayTimes = (times: IHolidayTimes[]) =>
 
 /** we sometimes get hh:mm:ss separate from the main utc date string from the API  */
 export const formatTimeFromString = (time: string) =>
-  new Date('1970-01-01T' + time + 'Z').toLocaleTimeString('en-gb', {
+  new Date('1970-01-01T' + time + 'Z').toLocaleTimeString('en-US', {
     timeZone: 'UTC',
     hour12: true,
     hour: 'numeric',


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/2352/introduce-end-dates-time-on-events

Included end date and time for events on event detail page and event card. 

### Development checklist
- [ ] The code has been linted `yarn lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
