### PR TITLE
2352: Event description isn't rendered as markdown

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -189,3 +189,37 @@ button {
 .relative {
   position: relative;
 }
+
+.richtext-content {
+  h2, h3 {
+    margin-left: 0 !important;
+    margin-bottom: 1.5rem;
+  }
+
+  h3 {
+    @include for-phone-only {
+      font-size: $font-body-l;
+    }
+  }
+
+  & > p {
+    @include body-m;
+  }
+
+  & > p, & > ul {
+    margin-bottom: space(24) !important;
+  }
+
+  ul {
+    padding-left: space(20);
+    list-style-position: outside;
+
+    li {
+      @include body-m;
+
+      &:not(:last-child) {
+        margin-bottom: space(12);
+      }
+    }
+  }
+}

--- a/src/views/EventDetail/EventDetail.tsx
+++ b/src/views/EventDetail/EventDetail.tsx
@@ -7,6 +7,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import moment from 'moment';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import ReactMarkdown from 'react-markdown';
 
 import InductionLoop from '../../assets/images/icons/accessibility/induction-loop.svg';
 import Wheelchair from '../../assets/images/icons/accessibility/wheelchair.svg';
@@ -165,7 +166,7 @@ const EventDetail: React.FC<IProps> = ({ eventStore, match }) => {
           </div>
           <div className="flex-col flex-col--8 flex-col--mobile--12 flex-col--tablet--12 service__left-column">
             <Accordian title="Event description" className="service__accordian mobile-show">
-              <p className="p--large">{event.description}</p>
+              <div className='richtext-content'><ReactMarkdown source={event.description} /></div>
               {event.has_image && (
                 <div className="description-image">
                   <img
@@ -310,7 +311,7 @@ const EventDetail: React.FC<IProps> = ({ eventStore, match }) => {
             )}
 
             <div className="panel-box__white mobile-hide margin-bottom">
-              <p className="p--large">{event.description}</p>
+              <div className='richtext-content'><ReactMarkdown source={event.description} /></div>
               {event.has_image && (
                 <div className="description-image">
                   <img


### PR DESCRIPTION
### Summary
https://app.shortcut.com/ayup-digital-ltd/story/2353/event-description-isn-t-rendered-as-markdown

styled markdown content for events desc

### Development checklist
- [ ] The code has been linted `yarn lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
