### PR TITLE
only output enabled events for events dropdown

### DIFF
--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -109,7 +109,9 @@ class EventStore {
     try {
       const data = await axios.get(`${apiBase}/collections/organisation-events`);
       const getData = get(data, 'data.data', []);
-      const getValues = map(getData, obj => pick(obj, ['name']));
+      const getValues = map(getData, obj => pick(obj, ['name', 'enabled'])).filter(
+        _ => _.enabled === true
+      );
       this.eventCategoryOptions = getValues.map(({ name: text }) => ({ value: text, text }));
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
### Summary
- https://app.shortcut.com/ayup-digital-ltd/story/2561/disabled-event-collections-are-not-hidden

only output enabled events for events dropdown

### Development checklist
- [ ] The code has been linted `yarn lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
